### PR TITLE
 Added possibility to open Link module just after loading the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ class App extends Component {
         product={["auth", "transactions"]}
         publicKey="PLAID_PUBLIC_KEY"
         onExit={this.handleOnExit}
-        onSuccess={this.handleOnSuccess}>
+        onSuccess={this.handleOnSuccess}
+        openOnLoad={false}
+      >
         Open Link and connect your bank!
       </PlaidLink>
     )

--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -37,7 +37,7 @@ class PlaidLink extends Component {
   static propTypes = {
     // ApiVersion flag to use new version of Plaid API
     apiVersion: PropTypes.string,
-    
+
     // Displayed once a user has successfully linked their account
     clientName: PropTypes.string.isRequired,
 
@@ -100,6 +100,9 @@ class PlaidLink extends Component {
 
     // Button Class names as a String
     className: PropTypes.string,
+
+    // If true, the Link module will be opened after it has finished loading
+    openOnLoad: PropTypes.bool,
   }
 
   onScriptError() {
@@ -123,6 +126,10 @@ class PlaidLink extends Component {
     });
 
     this.setState({ disabledButton: false });
+
+    if (this.props.openOnLoad) {
+      window.linkHandler.open();
+    }
   }
 
   handleLinkOnLoad() {

--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -128,7 +128,7 @@ class PlaidLink extends Component {
     this.setState({ disabledButton: false });
 
     if (this.props.openOnLoad) {
-      window.linkHandler.open();
+      this.handleOnClick();
     }
   }
 
@@ -158,7 +158,7 @@ class PlaidLink extends Component {
   render() {
     return (
       <div>
-        {this.props.openOnLoad && (
+        {!this.props.openOnLoad && (
           <button
             onClick={this.handleOnClick}
             disabled={this.state.disabledButton}

--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -158,13 +158,15 @@ class PlaidLink extends Component {
   render() {
     return (
       <div>
-        <button
-          onClick={this.handleOnClick}
-          disabled={this.state.disabledButton}
-          style={this.props.style}
-          className={this.props.className}>
-          {this.props.children}
-        </button>
+        {this.props.openOnLoad && (
+          <button
+            onClick={this.handleOnClick}
+            disabled={this.state.disabledButton}
+            style={this.props.style}
+            className={this.props.className}>
+            {this.props.children}
+          </button>
+        )}
         <Script
           url={this.state.initializeURL}
           onError={this.onScriptError}


### PR DESCRIPTION
This feature might be useful if you want to display Plaid Link module to the user without performing any action by him.

Passing `openOnLoad` prop will prevent rendering the button and will cause opening the module just after loading the script.