### PR TITLE
usePlaidLink Hook 🎉

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
   "presets": ["es2015", "react"],
-  "plugins": ["transform-class-properties"]
+  "plugins": ["transform-class-properties", "transform-object-rest-spread"]
 }

--- a/examples/simple/app.js
+++ b/examples/simple/app.js
@@ -39,7 +39,6 @@ class App extends Component {
         product={['auth', 'transactions']}
         publicKey="614be98f819e9bd8d0db9abec1c08a"
         className="some-class-name"
-        apiVersion="v2"
         onSuccess={this.handleOnSuccess}
         onExit={this.handleOnExit}
         onEvent={this.handleOnEvent}

--- a/package.json
+++ b/package.json
@@ -27,11 +27,12 @@
     "example": "examples"
   },
   "dependencies": {
-    "react-load-script": "0.0.6"
+    "react-load-script": "0.0.6",
+    "react-script-hook": "^1.0.11"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0 || ^16",
-    "react-dom": "^0.14.0 || ^15.0.0 || ^16"
+    "react": "^16.8.0",
+    "react-dom": "^16.8.0"
   },
   "devDependencies": {
     "babel-cli": "6.26.x",
@@ -48,8 +49,8 @@
     "eslint-plugin-react": "5.2.x",
     "mocha": "2.3.x",
     "prop-types": "^15.5.10",
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
+    "react": "^16.10.2",
+    "react-dom": "^16.10.2",
     "react-tools": "0.13.x",
     "sinon": "1.17.x",
     "webpack": "^3.6.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "example": "examples"
   },
   "dependencies": {
-    "react-load-script": "0.0.6",
     "react-script-hook": "^1.0.11"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "babel-eslint": "8.0.x",
     "babel-loader": "7.1.x",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-es2015": "6.5.x",
     "babel-preset-react": "6.5.x",
     "babel-preset-stage-0": "6.5.x",

--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -1,185 +1,145 @@
-import React, { Component } from 'react';
-import Script from 'react-load-script';
+import React, { forwardRef, useImperativeHandle } from 'react';
 import PropTypes from 'prop-types';
+import { usePlaidLink } from './usePlaidLink';
 
+const PlaidLink = forwardRef(function PlaidLink(props, ref) {
+  const {
+    clientName,
+    countryCodes,
+    env,
+    publicKey,
+    product,
+    language,
+    token,
+    userEmailAddress,
+    userLegalName,
+    webhook,
+    onSuccess,
+    onExit,
+    onLoad,
+    onEvent,
+    children,
+    action,
+    ...rest
+  } = props;
+  const { error, open, exit } = usePlaidLink({
+    clientName,
+    countryCodes,
+    env,
+    key: publicKey,
+    product,
+    language,
+    token,
+    userEmailAddress,
+    userLegalName,
+    webhook,
+    onSuccess,
+    onExit,
+    onLoad,
+    onEvent,
+  });
 
-
-class PlaidLink extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      disabledButton: true,
-      linkLoaded: false,
-      initializeURL: 'https://cdn.plaid.com/link/v2/stable/link-initialize.js',
-    };
-
-    this.onScriptError = this.onScriptError.bind(this);
-    this.onScriptLoaded = this.onScriptLoaded.bind(this);
-    this.handleLinkOnLoad = this.handleLinkOnLoad.bind(this);
-    this.handleOnClick = this.handleOnClick.bind(this);
-  }
-
-  static defaultProps = {
-    env: 'sandbox',
-    selectAccount: false,
-    token: null,
-    style: {
-      padding: '6px 4px',
-      outline: 'none',
-      background: '#FFFFFF',
-      border: '2px solid #F1F1F1',
-      borderRadius: '4px',
-    },
-  };
-
-  static propTypes = {
-    // ApiVersion flag to use new version of Plaid API
-    apiVersion: PropTypes.string,
-
-    // Displayed once a user has successfully linked their account
-    clientName: PropTypes.string.isRequired,
-
-    // List of countries to initialize Link with
-    countryCodes: PropTypes.array,
-
-    // The Plaid API environment on which to create user accounts.
-    // For development and testing, use tartan. For production, use production
-    env: PropTypes.oneOf(['tartan', 'sandbox', 'development', 'production']).isRequired,
-
-    // The public_key associated with your account; available from
-    // the Plaid dashboard (https://dashboard.plaid.com)
-    publicKey: PropTypes.string.isRequired,
-
-    // The Plaid products you wish to use, an array containing some of connect,
-    // auth, identity, income, transactions, assets, liabilities
-    product: PropTypes.arrayOf(
-      PropTypes.oneOf([
-        'connect',  // legacy product name
-        'info',     // legacy product name
-        'auth',
-        'identity',
-        'income',
-        'transactions',
-        'assets',
-        'liabilities',
-        'investments',
-      ])
-    ).isRequired,
-
-    // List of countries to initialize Link with
-    language: PropTypes.string,
-
-    // Specify an existing user's public token to launch Link in update mode.
-    // This will cause Link to open directly to the authentication step for
-    // that user's institution.
-    token: PropTypes.string,
-
-    // Specify a user object to enable all Auth features. Reach out to your
-    // account manager or integrations@plaid.com to get enabled. See the Auth
-    // [https://plaid.com/docs#auth] docs for integration details.
-    user: PropTypes.shape({
-      // Your user's legal first and last name
-      legalName: PropTypes.string,
-      // Your user's associated email address
-      emailAddress: PropTypes.string,
+  useImperativeHandle(
+    action,
+    () => ({
+      open,
+      exit,
     }),
+    [open, exit],
+  );
 
-    // Set to true to launch Link with the 'Select Account' pane enabled.
-    // Allows users to select an individual account once they've authenticated
-    selectAccount: PropTypes.bool,
+  return (
+    <button
+      disabled={Boolean(error)}
+      style={{
+        padding: '6px 4px',
+        outline: 'none',
+        background: '#FFFFFF',
+        border: '2px solid #F1F1F1',
+        borderRadius: '4px',
+      }}
+      {...rest}
+      ref={ref}
+      onClick={e => {
+        if (props.onClick) {
+          props.onClick(e);
+        }
+        if (e.isDefaultPrevented()) {
+          return;
+        }
+        open();
+      }}>
+      {children}
+    </button>
+  );
+});
+PlaidLink.propTypes = {
+  // Displayed once a user has successfully linked their account
+  clientName: PropTypes.string.isRequired,
 
-    // Specify a webhook to associate with a user.
-    webhook: PropTypes.string,
+  // List of countries to initialize Link with
+  countryCodes: PropTypes.array,
 
-    // A function that is called when a user has successfully onboarded their
-    // account. The function should expect two arguments, the public_key and a
-    // metadata object
-    onSuccess: PropTypes.func.isRequired,
+  // The Plaid API environment on which to create user accounts.
+  env: PropTypes.oneOf(['sandbox', 'development', 'production']).isRequired,
 
-    // A function that is called when a user has specifically exited Link flow
-    onExit: PropTypes.func,
+  // The public_key associated with your account; available from
+  // the Plaid dashboard (https://dashboard.plaid.com)
+  publicKey: PropTypes.string.isRequired,
 
-    // A function that is called when the Link module has finished loading.
-    // Calls to plaidLinkHandler.open() prior to the onLoad callback will be
-    // delayed until the module is fully loaded.
-    onLoad: PropTypes.func,
+  // The Plaid products you wish to use, an array containing some of connect,
+  // auth, identity, income, transactions, assets, liabilities
+  product: PropTypes.arrayOf(
+    PropTypes.oneOf([
+      'connect',  // legacy product name
+      'info',     // legacy product name
+      'auth',
+      'identity',
+      'income',
+      'transactions',
+      'assets',
+      'liabilities',
+      'investments',
+    ])
+  ).isRequired,
 
-    // A function that is called during a user's flow in Link.
-    // See
-    onEvent: PropTypes.func,
+  // List of countries to initialize Link with
+  language: PropTypes.string,
 
-    // Button Styles as an Object
-    style: PropTypes.object,
+  // Specify an existing user's public token to launch Link in update mode.
+  // This will cause Link to open directly to the authentication step for
+  // that user's institution.
+  token: PropTypes.string,
 
-    // Button Class names as a String
-    className: PropTypes.string,
-  }
+  // Your user's legal first and last name
+  // Specify to enable all Auth features.
+  // Note that userEmailAddress must also be set.
+  userLegalName: PropTypes.string,
 
-  onScriptError() {
-    console.error('There was an issue loading the link-initialize.js script');
-  }
+  // Your user's associated email address
+  // Specify to enable all Auth features.
+  // Note that userLegalName must also be set.
+  userEmailAddress: PropTypes.string,
 
-  onScriptLoaded() {
-    this.linkHandler = window.Plaid.create({
-      apiVersion: this.props.apiVersion,
-      clientName: this.props.clientName,
-      countryCodes: this.props.countryCodes,
-      language: this.props.language,
-      env: this.props.env,
-      key: this.props.publicKey,
-      onEvent: this.props.onEvent,
-      onExit: this.props.onExit,
-      onLoad: this.handleLinkOnLoad,
-      onSuccess: this.props.onSuccess,
-      product: this.props.product,
-      selectAccount: this.props.selectAccount,
-      token: this.props.token,
-      user: this.props.user,
-      webhook: this.props.webhook,
-    });
+  // Specify a webhook to associate with a user.
+  webhook: PropTypes.string,
 
-    this.setState({ disabledButton: false });
-  }
+  // A function that is called when a user has successfully onboarded their
+  // account. The function should expect two arguments, the public_key and a
+  // metadata object
+  onSuccess: PropTypes.func.isRequired,
 
-  handleLinkOnLoad() {
-    if (this.props.onLoad != null) {
-      this.props.onLoad();
-    }
-    this.setState({ linkLoaded: true });
-  }
+  // A function that is called when a user has specifically exited Link flow
+  onExit: PropTypes.func,
 
-  handleOnClick(event) {
-    if (this.props.onClick != null) {
-      this.props.onClick(event);
-    }
-    if (this.linkHandler) {
-      this.linkHandler.open();
-    }
-  }
+  // A function that is called when the Link module has finished loading.
+  // Calls to plaidLinkHandler.open() prior to the onLoad callback will be
+  // delayed until the module is fully loaded.
+  onLoad: PropTypes.func,
 
-  exit(configurationObject) {
-    if (this.linkHandler) {
-      this.linkHandler.exit(configurationObject);
-    }
-  }
-
-  render() {
-    return (
-      <div>
-        <button
-          onClick={this.handleOnClick}
-          disabled={this.state.disabledButton}
-          style={this.props.style}
-          className={this.props.className}>
-          {this.props.children}
-        </button>
-        <Script
-          url={this.state.initializeURL}
-          onError={this.onScriptError}
-          onLoad={this.onScriptLoaded} />
-      </div>
-    );
-  }
-}
+  // A function that is called during a user's flow in Link.
+  // See
+  onEvent: PropTypes.func,
+};
 
 export default PlaidLink;

--- a/src/factory.js
+++ b/src/factory.js
@@ -1,0 +1,75 @@
+
+/**
+ * Wrap link handler creation and instance to clean up iframe via destroy() method
+ */
+export const createPlaid = options => {
+  if (typeof window === 'undefined' || !window.Plaid) {
+    throw new Error('Plaid not loaded');
+  }
+
+  // Use object for state so inner functions can reference
+  // properties created/updated later
+  const state = {
+    plaid: null,
+    iframe: null,
+    open: false,
+  };
+
+  state.plaid = window.Plaid.create({
+    ...options,
+    onEvent: (eventName, metadata) => {
+      if (eventName === 'EXIT' || eventName === 'HANDOFF') {
+        state.open = false;
+      }
+      if (options.onEvent) {
+        options.onEvent(eventName, metadata);
+      }
+    },
+  });
+
+  // Keep track of Plaid DOM instance so we can clean up it for them.
+  // It's reasonably safe to assume the last plaid iframe will be the one
+  // just created by the line above.
+  state.iframe = document.querySelector(
+    'iframe[id^="plaid-link-iframe-"]:last-child'
+  );
+
+  const open = () => {
+    if (!state.plaid) {
+      return;
+    }
+    state.open = true;
+    state.plaid.open();
+  };
+  const exit = opts => {
+    if (!state.open || !state.plaid) {
+      return;
+    }
+    state.plaid.exit(opts);
+    if (opts && opts.force) {
+      state.open = false;
+    }
+  };
+  const destroy = () => {
+    const wasOpen = state.open;
+    exit({ force: true });
+    const cleanup = () => {
+      if (state.iframe) {
+        state.iframe.remove();
+        state.iframe = null;
+      }
+    };
+    // If was open give Plaid some time to finish before killing iframe.
+    if (wasOpen && state.iframe) {
+      setTimeout(cleanup, 1000);
+    } else {
+      cleanup();
+    }
+  };
+
+  return {
+    open,
+    exit,
+    destroy,
+  };
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 import PlaidLink from './PlaidLink';
 
 export default PlaidLink;
+export * from './usePlaidLink';

--- a/src/usePlaidLink.js
+++ b/src/usePlaidLink.js
@@ -1,0 +1,77 @@
+import { useEffect, useState } from 'react';
+import useScript from 'react-script-hook';
+import { createPlaid } from './factory';
+
+/**
+ * This hook loads Plaid script and manages the Plaid Link creation for you.
+ * You get easy open & exit methods to call and loading & error states.
+ *
+ * This will destroy the Plaid UI on un-mounting so it's up to you to be
+ * graceful to the user.
+ *
+ * A new Plaid instance is created every time the individual options change.
+ * It's up to you to prevent unnecessary re-creations on re-render.
+ */
+export const usePlaidLink = options => {
+  const [loading, error] = useScript({
+    src: 'https://cdn.plaid.com/link/v2/stable/link-initialize.js',
+  });
+  const [plaid, setPlaid] = useState(null);
+  const [linkLoaded, setLinkLoaded] = useState(false);
+
+  useEffect(() => {
+    if (loading) {
+      return;
+    }
+    if (error || !window.Plaid) {
+      // eslint-disable-next-line no-console
+      console.error('Error loading Plaid', error);
+      return;
+    }
+
+    if (linkLoaded) {
+      setLinkLoaded(false);
+    }
+    const next = createPlaid({
+      ...options,
+      onLoad: () => {
+        if (options.onLoad) {
+          options.onLoad();
+        }
+        setLinkLoaded(true);
+      },
+    });
+    setPlaid(next);
+
+    return next.destroy;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    loading,
+    error,
+    options.clientName,
+    options.countryCodes,
+    options.env,
+    options.key,
+    // Be nice and handle array identity changes since it's just an array of strings.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    options.product.join(','),
+    options.language,
+    options.token,
+    options.userLegalName,
+    options.userEmailAddress,
+    options.webhook,
+    options.onSuccess,
+    options.onExit,
+    options.onLoad,
+    options.onEvent,
+  ]);
+
+  return {
+    loading: loading || !linkLoaded,
+    error,
+    open: plaid ? plaid.open : noop,
+    exit: plaid ? plaid.exit : noop,
+  };
+};
+
+const noop = () => {};


### PR DESCRIPTION
Supersedes #56 #27 #38 
Closes #60 #49 #46 #44 #42 #33 #32 #30 #26 

This creates `usePlaidLink` hook and moves all the heavy lifting there 💪 
I updated `PlaidLink` to use the hook, but IMO it's of little value now 💥 

This does bump the minimum required React version, so it's a breaking change and will need a major version.

## Usage
```js
const onSuccess = useCallback((token, metadata) => {
  // send token to server
}, []);
const { open, exit, loading, error } = usePlaidLink({
  clientName: '',
  env: 'sandbox',
  product: ['auth', 'transactions'],
  key: 'public_key',
  onSuccess,
  ...
});

return (
  <MyButton onClick={open} disabled={loading} ...>
    Open Plaid Link
  </MyButton>
);
```
Whenever the options passed to the hook change the hook creates a new plaid link handler instance with the updated options and kills the old one. Because of this, all callbacks need to be wrapped with `useCallback` so their identities don't change.
The hook handles removing old DOM iframes when unmounting or updating 🎉 

## TypeScript

I wrote this implementation in TypeScript, but I didn't want to force that here. But if desired I can update this PR to be written in TypeScript. 💯 
Otherwise, I would like to open another PR that adds the type definitions.
If that's still unwanted, I'll just submit updates to DefinitelyTyped.

## `PlaidLink` Component
- I updated implementation so all non-plaid options are passed through to `button`.
- I changed the `ref` to point to the html button element, and added an `action` ref prop that will give access to imperative API (`open()`, `exit()`).

If you want to use a custom component, then just use the hook instead :wink:

I updated the prop types, but I'm not sure if they are correct. I've never used prop types because TypeScript... 😎 

Since this is a major version, maybe we should just consider removing this component all together... 🤔 

---

Happy to talk through this, answer questions, and adjust as needed 😄  