### PR TITLE
fix(PlaidLink): replacing div with React.Fragment

### DIFF
--- a/src/PlaidLink.js
+++ b/src/PlaidLink.js
@@ -165,7 +165,7 @@ class PlaidLink extends Component {
 
   render() {
     return (
-      <div>
+      <React.Fragment>
         <button
           onClick={this.handleOnClick}
           disabled={this.state.disabledButton}
@@ -177,7 +177,7 @@ class PlaidLink extends Component {
           url={this.state.initializeURL}
           onError={this.onScriptError}
           onLoad={this.onScriptLoaded} />
-      </div>
+      </React.Fragment>
     );
   }
 }


### PR DESCRIPTION
Avoids adding an unnecessary div to the dom by using a fragment.