### PR TITLE
Add `className` prop to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ a more holistic understanding of the various Link options.
   onLoad={this.handleOnLoad}
   onSuccess={this.handleOnSuccess}
   style={{width: '100px'}}
+  className='custom-class'
   countryCodes={['US', 'CA']}
   language="en"
   user={{legalName: 'Jane Doe', emailAddress: 'jane@example.com'}}


### PR DESCRIPTION
The README section for all props did not mention the `className` prop. The `className` prop however is supported and is passed down to the button