### PR TITLE
Fix React component readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ export default App;
 import React from 'react';
 import { PlaidLink } from 'react-plaid-link';
 
-const App = () => {
+class App extends React.Component {
   const onSuccess = (token, metadata) => {
     // send token to server
   }


### PR DESCRIPTION
The readme calls `render()` on a function component. Just changed the typo to use a class component instead. 

Glad to see activity in this Repo! 