### PR TITLE
Remove console log from factory.ts

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -38,7 +38,6 @@ export const createPlaid = (options: PlaidLinkOptions) => {
   }
 
   const config = renameKeyInObject(options, 'publicKey', 'key');
-  console.log(config);
   state.plaid = window.Plaid.create(config);
 
   // Keep track of Plaid DOM instance so we can clean up it for them.


### PR DESCRIPTION
Hi! I started using `usePlaidLink` and noticed a `console.log` call.