### PR TITLE
Add support for link_tokens 

### DIFF
--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -31,6 +31,7 @@ stories.add('hooks', () => {
     clientName: text('clientName', 'YOUR_CLIENT_NAME'),
     env: select('env', ['sandbox', 'development', 'production'], 'sandbox'),
     publicKey: text('publicKey', '<SANDBOX_PUBLIC_KEY>'),
+    token: text('token', '<LINK_TOKEN>'),
     product: options(
       'product',
       { auth: 'auth', transactions: 'transactions' },
@@ -53,6 +54,7 @@ stories.add('HOC', () => {
     clientName: text('clientName', 'YOUR_CLIENT_NAME'),
     env: select('env', ['sandbox', 'development', 'production'], 'sandbox'),
     publicKey: text('publicKey', '<SANDBOX_PUBLIC_KEY>'),
+    token: text('token', '<LINK_TOKEN>'),
     product: options(
       'product',
       { auth: 'auth', transactions: 'transactions' },
@@ -62,6 +64,7 @@ stories.add('HOC', () => {
   };
 
   button('Save Link configuration', reRender);
+
   return (
     <div key={counter}>
       <ExampleComponent file="hoc" {...props} />

--- a/examples/hoc.js
+++ b/examples/hoc.js
@@ -18,6 +18,7 @@ const App = props => {
         env={props.env || 'sandbox'}
         product={props.product || ['auth', 'transactions']}
         publicKey={props.publicKey || '...'}
+        token={props.token}
         onExit={onExit}
         onSuccess={onSuccess}
         onEvent={onEvent}

--- a/examples/hooks.js
+++ b/examples/hooks.js
@@ -9,12 +9,12 @@ const App = props => {
   );
 
   const onEvent = useCallback(
-    (token, metadata) => console.log('onEvent', token, metadata),
+    (eventName, metadata) => console.log('onEvent', eventName, metadata),
     []
   );
 
   const onExit = useCallback(
-    (token, metadata) => console.log('onExit', token, metadata),
+    (err, metadata) => console.log('onExit', err, metadata),
     []
   );
 
@@ -23,6 +23,7 @@ const App = props => {
     env: props.env || 'sandbox',
     product: props.product || ['auth'],
     publicKey: props.publicKey,
+    token: props.token,
     onSuccess,
     onEvent,
     onExit,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,13 +1,10 @@
 import React from 'react';
 
-export interface PlaidLinkOptions {
+interface CommonPlaidLinkOptions {
   // Displayed once a user has successfully linked their account
   clientName: string;
   // The Plaid API environment on which to create user accounts.
   env: string;
-  // The public_key associated with your account; available from
-  // the Plaid dashboard (https://dashboard.plaid.com)
-  publicKey: string;
   // The Plaid products you wish to use, an array containing some of connect,
   // auth, identity, income, transactions, assets, liabilities
   product: Array<string>;
@@ -18,10 +15,6 @@ export interface PlaidLinkOptions {
   countryCodes?: Array<string>;
   // A local string to change the default Link display language
   language?: string;
-  // Specify an existing user's public token to launch Link in update mode.
-  // This will cause Link to open directly to the authentication step for
-  // that user's institution.
-  token?: string;
   // Your user's associated email address - specify to enable all Auth features.
   // Note that userLegalName must also be set.
   userEmailAddress?: string;
@@ -46,16 +39,34 @@ export interface PlaidLinkOptions {
   onEvent?: Function;
 }
 
-export interface PlaidLinkPropTypes extends PlaidLinkOptions {
+// Either the publicKey or the token field must be configured
+export type PlaidLinkOptions =
+  CommonPlaidLinkOptions & {
+    // The public_key associated with your account; available from
+    // the Plaid dashboard (https://dashboard.plaid.com)
+    publicKey: string;
+    token?: string;
+  } |
+  CommonPlaidLinkOptions & {
+    // Specify an item add token to launch link in normal mode.
+    // 
+    // Specify an existing user's public token to launch Link in update mode.
+    // This will cause Link to open directly to the authentication step for
+    // that user's institution.
+    token: string;
+  };
+
+export type PlaidLinkPropTypes = PlaidLinkOptions & {
   children: React.ReactNode;
   className?: string;
   style?: React.CSSProperties;
-}
+};
 
 export interface Plaid {
   open: Function;
   exit: Function;
   create: Function;
+  destroy: Function;
 }
 
 declare global {

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -39,6 +39,12 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
       return;
     }
 
+    // if an old plaid instance exists, destroy it before
+    // creating a new one
+    if (plaid != null) {
+      plaid.destroy();
+    }
+
     const next = createPlaid({
       ...options,
       onLoad: () => {
@@ -51,7 +57,7 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
 
     // on component unmount – destroy the Plaid iframe factory
     return next.destroy;
-  }, [loading, error]);
+  }, [loading, error, options.token]);
 
   return {
     error,

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -58,5 +58,6 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
     ready: !loading || iframeLoaded,
     exit: plaid ? plaid.exit : noop,
     open: plaid ? plaid.open : noop,
+    destroy: plaid ? plaid.destroy : noop,
   };
 };

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -64,6 +64,5 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
     ready: !loading || iframeLoaded,
     exit: plaid ? plaid.exit : noop,
     open: plaid ? plaid.open : noop,
-    destroy: plaid ? plaid.destroy : noop,
   };
 };

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -42,7 +42,7 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
     // if an old plaid instance exists, destroy it before
     // creating a new one
     if (plaid != null) {
-      plaid.destroy();
+      plaid.exit({ force: true }, () => plaid.destroy());
     }
 
     const next = createPlaid({
@@ -55,8 +55,8 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
 
     setPlaid(next);
 
-    // on component unmount – destroy the Plaid iframe factory
-    return next.destroy;
+    // destroy the Plaid iframe factory
+    return () => next.exit({ force: true }, () => next.destroy());
   }, [loading, error, options.token]);
 
   return {


### PR DESCRIPTION
- Allows public_key to be optional if a token is provided
- Recreates the link handler if the token is updated
- Use the new link handler `.destroy()` method instead of the one-off implementation here