### PR TITLE
Pull in fixed version of react-script-hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "react-script-hook": "^1.0.15"
+    "tr-tmp-react-script-hook": "1.0.17"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "tr-tmp-react-script-hook": "1.0.17"
+    "react-script-hook": "1.0.17"
   },
   "peerDependencies": {
     "react": "^16.8.0",


### PR DESCRIPTION
Use a version of `react-script-hook` with https://github.com/hupe1980/react-script-hook/pull/10 is merged.