### PR TITLE
Ensure Plaid link-initialize.js is embedded only once

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "react-script-hook": "1.0.17"
+    "react-script-hook": "1.1.0"
   },
   "peerDependencies": {
     "react": "^16.8.0",

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -21,7 +21,7 @@ const noop = () => {};
  */
 export const usePlaidLink = (options: PlaidLinkOptions) => {
   // Asynchronously load the plaid/link/stable url into the DOM
-  const [loading, error] = useScript({ src: PLAID_LINK_STABLE_URL });
+  const [loading, error] = useScript({ src: PLAID_LINK_STABLE_URL, checkForExisting: true });
 
   // internal state
   const [plaid, setPlaid] = useState<PlaidFactory | null>(null);

--- a/yarn.lock
+++ b/yarn.lock
@@ -9135,10 +9135,10 @@ react-popper@^1.3.6:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-script-hook@1.0.17:
-  version "1.0.17"
-  resolved "https://npm.plaid.com/r/react-script-hook/_attachments/react-script-hook-1.0.17.tgz#9c3c3bd196d677d48838ac09134c912d555c67a9"
-  integrity sha512-maLLOqAfHcbcQPwDo9wuqdCzHSbyL/uDhULtb7Yrvh8IrbNN24LRXluHnti8Y+bk0LNn3s15esl3wDVeCMjbIg==
+react-script-hook@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/react-script-hook/-/react-script-hook-1.1.0.tgz#f88bb74b1c89250d7577e6cd5472f10992190706"
+  integrity sha512-swEdGFIOgG4lfi1gdYzFNV28uKuowzbgEGb8Lwi/yp696BVa6RvvuW4a7FY9mic+SecojVlHMWcllygmAg6EJg==
 
 react-select@^3.0.8:
   version "3.0.8"


### PR DESCRIPTION
This fixes #107 by upgrading `react-script-hook` to 1.1.0 and using the `checkIfExisting` flag