### PR TITLE
Add support for open method to take in additional arguments

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -51,13 +51,15 @@ export const createPlaid = (options: PlaidLinkOptions) => {
     },
   });
 
-  const open = () => {
+  // Depending on settings configured, some use cases might support open method to take in some arugments
+  // Ex. Passing institution_type to open institution directly
+  const open = (...args: any[]) => {
     if (!state.plaid) {
       return;
     }
     state.open = true;
     state.onExitCallback = null;
-    state.plaid.open();
+    state.plaid.open(...args);
   };
 
   const exit = (exitOptions: any, callback: Function) => {


### PR DESCRIPTION
Some use cases allow `open` method to take in `institution_type`(ex. ins_3) to open Plaid directly to that institution credentials.

To support flexibility for uncertain amount of arguments, I added a spread on all arguments possibility.