### PR TITLE
update typescript types for optional configs

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,7 +12,6 @@ interface CommonPlaidLinkOptions {
   onLoad?: Function;
   // A callback that is called during a user's flow in Link.
   onEvent?: Function;
-  oauthStateId?: string;
 }
 
 export type PlaidLinkOptionsWithPublicKey = (CommonPlaidLinkOptions & {
@@ -44,6 +43,7 @@ export type PlaidLinkOptionsWithPublicKey = (CommonPlaidLinkOptions & {
   accountSubtypes?: { [key: string]: Array<string> };
   oauthNonce?: string;
   oauthRedirectUri?: string;
+  oauthStateId?: string;
   paymentToken?: string;
 });
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,7 +2,7 @@ import React from 'react';
 
 interface CommonPlaidLinkOptions {
   // Displayed once a user has successfully linked their account
-  clientName?: string;
+  clientName: string;
   // The Plaid API environment on which to create user accounts.
   env?: string;
   // The Plaid products you wish to use, an array containing some of connect,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,12 +2,12 @@ import React from 'react';
 
 interface CommonPlaidLinkOptions {
   // Displayed once a user has successfully linked their account
-  clientName: string;
+  clientName?: string;
   // The Plaid API environment on which to create user accounts.
-  env: string;
+  env?: string;
   // The Plaid products you wish to use, an array containing some of connect,
   // auth, identity, income, transactions, assets, liabilities
-  product: Array<string>;
+  product?: Array<string>;
   // A function that is called when a user has successfully connecter an Item.
   // The function should expect two arguments, the public_key and a metadata object
   onSuccess: Function;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,16 +1,33 @@
 import React from 'react';
 
 interface CommonPlaidLinkOptions {
-  // Displayed once a user has successfully linked their account
-  clientName: string;
-  // The Plaid API environment on which to create user accounts.
-  env?: string;
-  // The Plaid products you wish to use, an array containing some of connect,
-  // auth, identity, income, transactions, assets, liabilities
-  product?: Array<string>;
   // A function that is called when a user has successfully connecter an Item.
   // The function should expect two arguments, the public_key and a metadata object
   onSuccess: Function;
+  // A callback that is called when a user has specifically exited Link flow
+  onExit?: Function;
+  // A callback that is called when the Link module has finished loading.
+  // Calls to plaidLinkHandler.open() prior to the onLoad callback will be
+  // delayed until the module is fully loaded.
+  onLoad?: Function;
+  // A callback that is called during a user's flow in Link.
+  onEvent?: Function;
+  oauthStateId?: string;
+}
+
+export type PlaidLinkOptionsWithPublicKey = (CommonPlaidLinkOptions & {
+  // The public_key associated with your account; available from
+  // the Plaid dashboard (https://dashboard.plaid.com)
+  publicKey: string;
+  // Provide a public_token to initialize Link in update mode.
+  token?: string;
+  // Displayed once a user has successfully linked their account
+  clientName: string;
+  // The Plaid API environment on which to create user accounts.
+  env: string;
+  // The Plaid products you wish to use, an array containing some of connect,
+  // auth, identity, income, transactions, assets, liabilities
+  product: Array<string>;
   // An array of countries to filter institutions
   countryCodes?: Array<string>;
   // A local string to change the default Link display language
@@ -27,34 +44,20 @@ interface CommonPlaidLinkOptions {
   accountSubtypes?: { [key: string]: Array<string> };
   oauthNonce?: string;
   oauthRedirectUri?: string;
-  oauthStateId?: string;
   paymentToken?: string;
-  // A callback that is called when a user has specifically exited Link flow
-  onExit?: Function;
-  // A callbac that is called when the Link module has finished loading.
-  // Calls to plaidLinkHandler.open() prior to the onLoad callback will be
-  // delayed until the module is fully loaded.
-  onLoad?: Function;
-  // A callback that is called during a user's flow in Link.
-  onEvent?: Function;
-}
+});
 
-// Either the publicKey or the token field must be configured
-export type PlaidLinkOptions =
-  | (CommonPlaidLinkOptions & {
-      // The public_key associated with your account; available from
-      // the Plaid dashboard (https://dashboard.plaid.com)
-      publicKey: string;
-      token?: string;
-    })
-  | (CommonPlaidLinkOptions & {
-      // Specify an item add token to launch link in normal mode.
-      //
-      // Specify an existing user's public token to launch Link in update mode.
-      // This will cause Link to open directly to the authentication step for
-      // that user's institution.
-      token: string;
-    });
+export type PlaidLinkOptionsWithLinkToken = (CommonPlaidLinkOptions & {
+  // Provide a link_token associated with your account. Create one
+  // using the /link/token/create endpoint.
+  token: string;
+  receivedRedirectUri?: string;
+});
+
+// Either the publicKey or the token field must be configured. The publicKey
+// is deprecated so prefer to initialize Link with a Link Token instead.
+export type PlaidLinkOptions = 
+  PlaidLinkOptionsWithPublicKey | PlaidLinkOptionsWithLinkToken;
 
 export type PlaidLinkPropTypes = PlaidLinkOptions & {
   children: React.ReactNode;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -51,6 +51,8 @@ export type PlaidLinkOptionsWithLinkToken = (CommonPlaidLinkOptions & {
   // Provide a link_token associated with your account. Create one
   // using the /link/token/create endpoint.
   token: string;
+  // receivedRedirectUri is required on the second-initialization of link when using Link
+  // with a redirect_uri to support OAuth flows.
   receivedRedirectUri?: string;
 });
 

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -56,7 +56,6 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
 
     setPlaid(next);
 
-
     // destroy the Plaid iframe factory
     return () => next.exit({ force: true }, () => next.destroy());
   }, [loading, error, options.token, products]);

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import useScript from 'react-script-hook';
 
 import { createPlaid, PlaidFactory } from './factory';
-import { PlaidLinkOptions } from './types';
+import { PlaidLinkOptions, PlaidLinkOptionsWithPublicKey } from './types';
 
 const PLAID_LINK_STABLE_URL =
   'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
@@ -26,6 +26,7 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
   // internal state
   const [plaid, setPlaid] = useState<PlaidFactory | null>(null);
   const [iframeLoaded, setIframeLoaded] = useState(false);
+  const products = ((options as PlaidLinkOptionsWithPublicKey).product || []).slice().sort().join(',');
 
   useEffect(() => {
     // If the link.js script is still loading, return prematurely
@@ -55,9 +56,10 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
 
     setPlaid(next);
 
+
     // destroy the Plaid iframe factory
     return () => next.exit({ force: true }, () => next.destroy());
-    }, [loading, error, options.token, (options.product || []).slice().sort().join(',')]);
+  }, [loading, error, options.token, products]);
 
   return {
     error,


### PR DESCRIPTION
- The clientName, env, and product should now be empty if also using a link_token.