### PR TITLE
Update open state onExit

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -46,6 +46,7 @@ export const createPlaid = (options: PlaidLinkOptions) => {
   state.plaid = window.Plaid.create({
     ...config,
     onExit: (...params: any) => {
+      state.open = false;
       config.onExit && config.onExit(...params);
       state.onExitCallback && state.onExitCallback();
     },


### PR DESCRIPTION
Fix for issue #133. We were not setting the external `open` state to reflect a manually exited Link pane, causing the `destroy` method to be skipped when the Link pane was closed and then force exit triggered.