### PR TITLE
Return correct error messages

### DIFF
--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -34,7 +34,7 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
       return;
     }
 
-    if (error || !window.Plaid) {
+    if (error) {
       // eslint-disable-next-line no-console
       console.error('Error loading Plaid', error);
       return;


### PR DESCRIPTION
Within the effect hook, if error === null, but the Plaid instance doesn't exist on the window global, the error will be misreported to the console.

Fix:
- Check `error` in `usePlaidLink` and allow `createPlaid` to catch a `(typeof window === 'undefined' || !window.Plaid)` with descriptive error.