### PR TITLE
Update package.json to v3.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-plaid-link",
-  "version": "3.0.0",
+  "version": "3.1.1",
   "description": "A React component for Plaid Link",
   "files": [
     "dist",


### PR DESCRIPTION
Yarn and npm package registries still reflect 3.0.0. Looks like the package.json wasn't updated for the 3.1.1 release. This patch updates the Package.json. `yarn publish`, etc. will need to be run when this is merged.