### PR TITLE
Update changelog and create publish.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Changelog
 
-## 3.1.1
-- Fix a bug with the usePlaidLink `ready` state (#163)
-
 ## 3.1.0
 - Ensure Link is destroyed correctly (#146)
 - Export `PlaidLinkOptions` typescript types (#134)
 - (Internal) Bump node-fetch from 2.6.0 to 2.6.1 (#136)
 - (Internal) Bump elliptic from 6.5.2 to 6.5.3 (#127)
 - (Internal) Bump lodash from 4.17.15 to 4.17.19 (#124)
+- Fix a bug with the usePlaidLink `ready` state (#163)
 
 ## 3.0.0
 

--- a/Makefile
+++ b/Makefile
@@ -65,4 +65,4 @@ storybook-deploy:
 
 .PHONY: release-major release-minor release-patch
 release-major release-minor release-patch: build
-	@$(XYZ) --increment $(@:release-%=%)
+	@$(XYZ) --increment $(@:release-%=%) branch= $(branch) --dry-run

--- a/Makefile
+++ b/Makefile
@@ -65,4 +65,4 @@ storybook-deploy:
 
 .PHONY: release-major release-minor release-patch
 release-major release-minor release-patch: build
-	@$(XYZ) --increment $(@:release-%=%) branch= $(branch) --dry-run
+	@$(XYZ) --increment $(@:release-%=%) --branch $(BRANCH) --dry-run

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ NPM_ENV_VARS = npm_config_registry=https://registry.npmjs.org
 NPM = $(NPM_ENV_VARS) npm
 XYZ = $(NPM_ENV_VARS) node_modules/.bin/xyz --repo git@github.com:plaid/react-plaid-link.git
 STORYBOOK = node_modules/.bin/start-storybook
+RELEASE_BRANCH = release
 
 SRC_FILES  = $(shell find src -name '*.js|*.tsx|*.ts' | sort)
 
@@ -65,4 +66,4 @@ storybook-deploy:
 
 .PHONY: release-major release-minor release-patch
 release-major release-minor release-patch: build
-	@$(XYZ) --increment $(@:release-%=%) --branch $(BRANCH) --dry-run
+	@$(XYZ) --increment $(@:release-%=%) --branch $(RELEASE_BRANCH)

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,0 +1,23 @@
+## Publishing
+
+1. Run `make storybook` and verify that there are no regressions with Link.
+
+2. Pull the changes from `master` into `release`
+
+```
+git fetch
+git checkout release
+# this makes sure that the release branch is using latest master
+git reset --hard origin/master
+# this should not require force push unless we are rolling back
+git push origin release
+```
+
+
+You'll need NPM publishing rights for your NPM user. Then you can run:
+
+```
+make release-(patch|minor|major)
+```
+
+Read [semver](https://semver.org/) to determine what type of version bump to use.

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -13,8 +13,7 @@ git reset --hard origin/master
 git push origin release
 ```
 
-
-You'll need NPM publishing rights for your NPM user. Then you can run:
+3. Release from the `release` branch.
 
 ```
 make release-(patch|minor|major)

--- a/README.md
+++ b/README.md
@@ -108,12 +108,3 @@ type PlaidLinkOptions = PlaidLinkOptionsWithLinkToken;
 
 Typescript definitions for `react-plaid-link` are built into the npm packge.
 
-## Publishing
-
-You'll need NPM publishing rights for your NPM user. Then you can run:
-
-```
-make release-(patch|minor|major)
-```
-
-Read [semver](https://semver.org/) to determine what type of version bump to use.


### PR DESCRIPTION
1. Updates changelog because I just realized we never released anything after 3.0.0 according to npm.
2. Creates a publish.md to outline how to release to npm. This no longer requires write access to master to release.
