### PR TITLE
Get and pass jss nonce to options if it exists

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -37,6 +37,10 @@ export const createPlaid = (options: PlaidLinkOptions) => {
     throw new Error('Plaid not loaded');
   }
 
+  // Pass jss nonce if it's set
+  const nonceNode = document.querySelector('meta[property="csp-nonce"]')
+  options.nonce = nonceNode ? nonceNode.getAttribute('content') : null
+
   const config = renameKeyInObject(
     options,
     'publicKey',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,6 +12,8 @@ interface CommonPlaidLinkOptions {
   onLoad?: Function;
   // A callback that is called during a user's flow in Link.
   onEvent?: Function;
+  // jss nonce setting from the page if the user has set it.
+  nonce?: string | null
 }
 
 export type PlaidLinkOptionsWithPublicKey = (CommonPlaidLinkOptions & {


### PR DESCRIPTION
Seems the integrations is using inline styles. Meaning that CSP style-src need to allow `unsafe-inline`.
This PR is a suggestion on how we can use the nonce technique to don't allow `unsafe-inline`
This nonce will then need to be captured and set on link-initialize.js

Please let me know what do you think, or if there's some other alternative. 

Thanks

#118 is kinda related