### PR TITLE
Allow React 17 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "react-script-hook": "1.1.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.0",


### PR DESCRIPTION
closes #170 

tested with `create-react-app`, `react@17.0.1`, node `v14.15.4` (stable) and npm `v6.14.10` (stable)