### PR TITLE
fix(deps): bump react-script-hook to fix `Error loading plaid` msg

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "react-script-hook": "1.3.0"
+    "react-script-hook": "1.5.0"
   },
   "peerDependencies": {
     "react": "^16.8.0 || ^17.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9229,10 +9229,10 @@ react-popper@^1.3.7:
     typed-styles "^0.0.7"
     warning "^4.0.2"
 
-react-script-hook@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/react-script-hook/-/react-script-hook-1.3.0.tgz#edf2746ea46114fa4c38fdcf796a0ba82e6d53f8"
-  integrity sha1-7fJ0bqRhFPpMOP3PeWoLqC5tU/g=
+react-script-hook@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.npmjs.org/react-script-hook/-/react-script-hook-1.5.0.tgz#7d7eb189c92e01cf0a8d1796113947ef8e08eed5"
+  integrity sha512-LzWXi5rxT4xz+zLwCt7nTmMuFyFs04c5m6lHCs8Ps9U8J8zHQNp+E9IcLFSFzkn4WZMiNPt2DQUVeBHLy2Ix0w==
 
 react-select@^3.0.8:
   version "3.2.0"


### PR DESCRIPTION
The latest version of `react-plaid-link` throws an error `Error loading Plaid null` if the plaid script hasn't been initiated on time. 

The reason for it is that `react-script-hook@1.3.0` has a race condition when `checkForExisting` is set to `true`. 
Fortunately, the race condition has been fixed in `1.5.0` - commit: https://github.com/hupe1980/react-script-hook/commit/167085c6db62074f6f57d4271cd5c2a1b9a84e79

This PR should resolve this issue: https://github.com/plaid/react-plaid-link/issues/121
 