### PR TITLE
Set valid open state after success connection

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -50,6 +50,10 @@ export const createPlaid = (options: PlaidLinkOptions) => {
       config.onExit && config.onExit(error, metadata);
       state.onExitCallback && state.onExitCallback();
     },
+    onSuccess: (public_token, metadata) => {
+      state.open = false;
+      options.onSuccess && options.onSuccess(public_token, metadata)
+    },
   });
 
   const open = () => {

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -52,6 +52,9 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
         setIframeLoaded(true);
         options.onLoad && options.onLoad();
       },
+      onSuccess: (public_token, metadata) => {
+        options.onSuccess && options.onSuccess(public_token, metadata)
+      },
     });
 
     setPlaid(next);


### PR DESCRIPTION
**Bug summary:**
When `Link` is rendered in a component that is a `Route` element and Link was connected successfuly unless 1 time, link iframe is not destroyed after going to another `Route`.

**Preconditions:**
- Simple App with BrowserRouter
- 2 page:
1. first with Plaid Link (route `/`) and navigation link to second page
2. second should be blank, used only to emulate Route change (route `/test`)

**Steps to reproduce:**
- Use Link and connect to any Bank
- Enter valid credentials, start auth
- Should connect successfully & press `Continue` button to close the `Link`

**Expected:**
After changing route from `/` to `/test`, Plaid Link iframe should be destroyed

**Actual:**
After changing route from `/` to `/test`, Plaid Link iframe is not destroyed and affects other pages elements with artefacts

As I investigated, factory `open` state is not set to `false` after Link is successfully connected and closed via `Connect` button. So, when the `Link` was used at least once, the `open` state is `true` and iframe is hidden. As a result, plaid `exit` method skip calling its `callback` argument as `state.open` is still `true`.