### PR TITLE
(legacy) add support for deprecated publicKey config

### DIFF
--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -40,8 +40,11 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
       return;
     }
 
-    // If the token is undefined, return prematurely
-    if (!options.token) {
+    // If the token and publicKey is undefined, return prematurely
+    if (
+      !options.token &&
+      !(options as PlaidLinkOptionsWithPublicKey).publicKey
+    ) {
       return;
     }
 
@@ -69,7 +72,13 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
 
     // destroy the Plaid iframe factory
     return () => next.exit({ force: true }, () => next.destroy());
-  }, [loading, error, options.token, products]);
+  }, [
+    loading,
+    error,
+    (options as PlaidLinkOptionsWithPublicKey).publicKey,
+    options.token,
+    products,
+  ]);
 
   const ready = plaid != null && (!loading || iframeLoaded);
 


### PR DESCRIPTION
in 3.3.0 we inadvertently shipped a bug that broke integrations using a deprecated publicKey configuration along with the `usePlaidLink` hook. This was flagged in #239

This PR restores functionality of public keys by allowing the hook to load as long as 1 of `token` OR `publicKey` is set.

Tests for publicKey are added in #246 