### PR TITLE
chore: add missing transfer_status to `onSuccess` metadata types

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,7 @@ export interface PlaidLinkOnSuccessMetadata {
   institution: null | PlaidInstitution;
   accounts: Array<PlaidAccount>;
   link_session_id: string;
+  transfer_status?: string;
 }
 
 export interface PlaidLinkOnExitMetadata {


### PR DESCRIPTION
https://plaid.com/docs/link/web/#link-web-onsuccess-metadata-transfer-status