### PR TITLE
Export Plaid CDN to make it possible to load on App level

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { usePlaidLink } from './usePlaidLink';
+export { usePlaidLink, PLAID_LINK_STABLE_URL } from './usePlaidLink';
 export { PlaidLink } from './PlaidLink';
 export * from './types'

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -4,7 +4,7 @@ import useScript from 'react-script-hook';
 import { createPlaid, PlaidFactory } from './factory';
 import { PlaidLinkOptions, PlaidLinkOptionsWithPublicKey } from './types';
 
-const PLAID_LINK_STABLE_URL =
+export const PLAID_LINK_STABLE_URL =
   'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
 
 const noop = () => {};


### PR DESCRIPTION
We had this problem recently, where Plaid CDN was stuck on it's loading state after trying to be loaded after a routing change. Refreshing the page or accessing it directly would not cause this problem, with CDN being loaded without any problem.
Loading the CDN on App level on the first time it runs fixed the routing problem and it would be great to have it exported, so it won't mismatch if for some reason CDN link changes.