### PR TITLE
chore: Allow React 18 in `peerDependencies`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "react-script-hook": "^1.6.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.3",


### PR DESCRIPTION
this merges #250 into a plaid-owned branch so it can be built and merged