### PR TITLE
Remove unused prop-types dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     }
   },
   "dependencies": {
-    "prop-types": "^15.7.2",
     "react-script-hook": "^1.6.0"
   },
   "peerDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -9,7 +9,7 @@ import pkg from './package.json';
 export default [
   {
     input: 'src/index.ts',
-    external: ['react', 'prop-types'],
+    external: ['react'],
     output: [
       { file: pkg.main, format: 'cjs' },
       { file: pkg.module, format: 'es' },


### PR DESCRIPTION
In #87, as far as I can tell the use of `prop-types` was removed. This removes one remaining reference to it in the Rollup config as well as the package list.