### PR TITLE
update ready flag condition

### DIFF
--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -83,7 +83,7 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
     products,
   ]);
 
-  const ready = plaid != null && (!loading || iframeLoaded);
+  const ready = plaid != null && !loading && iframeLoaded;
 
   const openNoOp = () => {
     if (!options.token) {


### PR DESCRIPTION
Update `ready` flag considering the compulsion of `iframeLoaded` too otherwise `ready` will be true before `iframeLoaded` gets true and it causes screen flickers for a moment(reason might be iframe display none to block due to `iframeLoaded`). 

**Issue**

https://user-images.githubusercontent.com/14358475/223832863-67da6f02-1c1f-4f8c-b84f-2556398b5d8b.mov

