### PR TITLE
Support optional `institution_id` arg for `PlaidHandler.open()`

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -55,13 +55,13 @@ const createPlaidHandler = <T extends CommonPlaidLinkOptions<{}>>(
     },
   });
 
-  const open = () => {
+  const open: PlaidHandler['open'] = (...args) => {
     if (!state.plaid) {
       return;
     }
     state.open = true;
     state.onExitCallback = null;
-    state.plaid.open();
+    state.plaid.open(...args);
   };
 
   const exit = (exitOptions: any, callback: (() => void) | Function) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -166,7 +166,7 @@ export type PlaidLinkPropTypes = PlaidLinkOptions & {
 };
 
 export interface PlaidHandler {
-  open: () => void;
+  open: (institution_id?: string) => void; // the connect flow skips the 'Select your bank' step if `institution_id` is provided
   exit: (force?: boolean) => void;
   destroy: () => void;
 }


### PR DESCRIPTION
### Current behavior

When using `react-plaid-link`, `open()` ignores any argument passed in, so calling it with a specific institution ID will still require the user to select a bank on the first step of the Plaid Link flow.

### Expected behavior

The `open()` method returned by `usePlaidLink` should support the same arguments of `Plaid.create(...).open()` - specifically the first argument that allows the user to skip the institution selection step.

### Context

The `PlaidHandler` interface defined in https://cdn.plaid.com/link/v2/stable/link-initialize.js supports an argument that allows the user to skip the 'bank selection' step of Plaid Link. This is useful when an application implements its own bank selection interface to a user before starting the Plaid Link flow.

### Implementation notes

Using argument destructuring (`(...args) => { }`) + the spread operator will allow `react-plaid-link` to maintain signature parity with the upstream Plaid library even if the type definitions are not 100% up to date in the future. Type safety is unchanged.