### PR TITLE
Avoid `object`, `Function`, `any`, and `as T` type declarations, fix `exit()` arg type

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -6,26 +6,30 @@ import {
 
 import { EthereumOnboardingOptions } from './types/web3';
 
+export interface ExitOptions {
+  force?: boolean;
+}
+
 export interface PlaidFactory {
-  open: (() => void) | Function;
-  exit: ((exitOptions: any, callback: () => void) => void) | Function;
-  destroy: (() => void) | Function;
+  open: (() => void);
+  exit: ((exitOptions: ExitOptions, callback: () => void) => void);
+  destroy: (() => void);
 }
 
 interface FactoryInternalState {
   plaid: PlaidHandler | null;
   open: boolean;
-  onExitCallback: (() => void) | null | Function;
+  onExitCallback: (() => void) | null;
 }
 
-const renameKeyInObject = (
-  o: { [index: string]: any },
-  oldKey: string,
-  newKey: string
-): object => {
+const renameKeyInObject = <T extends Record<string, unknown>>(
+  o: T,
+  oldKey: keyof T,
+  newKey: keyof T
+): T => {
   const newObject = {};
   delete Object.assign(newObject, o, { [newKey]: o[oldKey] })[oldKey];
-  return newObject;
+  return newObject as T;
 };
 
 /**
@@ -64,7 +68,7 @@ const createPlaidHandler = <T extends CommonPlaidLinkOptions<{}>>(
     state.plaid.open();
   };
 
-  const exit = (exitOptions: any, callback: (() => void) | Function) => {
+  const exit = (exitOptions: ExitOptions, callback: (() => void)) => {
     if (!state.open || !state.plaid) {
       callback && callback();
       return;
@@ -107,7 +111,7 @@ export const createPlaid = (
     options,
     'publicKey',
     'key'
-  ) as PlaidLinkOptions;
+  );
 
   return createPlaidHandler(config, creator);
 };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -88,7 +88,7 @@ export type PlaidLinkOnEvent = (
 
 export type PlaidLinkOnLoad = () => void;
 
-export interface CommonPlaidLinkOptions<T> {
+export interface CommonPlaidLinkOptions<T> extends Record<string, unknown> {
   // A function that is called when a user has successfully connecter an Item.
   // The function should expect two arguments, the public_key and a metadata object
   onSuccess: T;
@@ -167,7 +167,7 @@ export type PlaidLinkPropTypes = PlaidLinkOptions & {
 
 export interface PlaidHandler {
   open: () => void;
-  exit: (force?: boolean) => void;
+  exit: (exitConfig?: { force?: boolean }) => void;
   destroy: () => void;
 }
 

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -2,12 +2,20 @@ import { useEffect, useState } from 'react';
 import useScript from 'react-script-hook';
 
 import { createPlaid, PlaidFactory } from './factory';
-import { PlaidLinkOptions, PlaidLinkOptionsWithLinkToken, PlaidLinkOptionsWithPublicKey } from './types';
+import { PlaidLinkOptions, PlaidLinkOptionsWithPublicKey } from './types';
 
 const PLAID_LINK_STABLE_URL =
   'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
 
 const noop = () => {};
+
+/**
+ * Type guard that allows type narrowing of PlaidLinkOptions to the deprecated PlaidLinkOptionsWithPublicKey
+ */
+const isPlaidLinkOptionsWithPublicKey = (options: PlaidLinkOptions): options is PlaidLinkOptionsWithPublicKey => {
+  return (options as PlaidLinkOptionsWithPublicKey).publicKey !== undefined;
+}
+
 
 /**
  * This hook loads Plaid script and manages the Plaid Link creation for you.
@@ -34,6 +42,8 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
     .sort()
     .join(',');
 
+  const hasPublicKey = isPlaidLinkOptionsWithPublicKey(options)
+
   useEffect(() => {
     // If the link.js script is still loading, return prematurely
     if (loading) {
@@ -43,8 +53,8 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
     // If the token, publicKey, and received redirect URI are undefined, return prematurely
     if (
       !options.token &&
-      !(options as PlaidLinkOptionsWithPublicKey).publicKey &&
-      !(options as PlaidLinkOptionsWithLinkToken).receivedRedirectUri
+      !hasPublicKey &&
+      !options.receivedRedirectUri
     ) {
       return;
     }
@@ -79,7 +89,7 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
   }, [
     loading,
     error,
-    (options as PlaidLinkOptionsWithPublicKey).publicKey,
+    hasPublicKey,
     options.token,
     products,
   ]);


### PR DESCRIPTION
This is an update to the type definitions in order to improve type safety and make the library a little easier to use in downstream TypeScript applications.

1. `object`, `Function`, and `any` type declarations are extremely permissive, and can broaden the accepted and returned types to the point where they are effectively untyped
   - https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html#any
   - https://www.typescriptlang.org/docs/handbook/2/functions.html#function
   - `object` means "any non-primitive type"
2. Using type assertions (e.g. `foo as Bar`) can be dangerous because the value might not actually match the asserted type. Instead, we can use [type guards](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates) to programmatically narrow the type based on a type predicate that we define.
3. The type declaration for the returned `exit` method was not correct - it has been fixed to match `exitOptions` expected by `Plaid.create().exit(exitOptions)`