### PR TITLE
Support embedded Link in Plaid React web SDK

### DIFF
--- a/.storybook/example.stories.js
+++ b/.storybook/example.stories.js
@@ -68,6 +68,20 @@ stories.add('web3', () => {
   );
 });
 
+stories.add('embedded Link', () => {
+  const props = {
+    token: text('token', ''),
+  };
+
+  button('Save Link configuration', reRender);
+
+  return (
+    <div key={counter}>
+      <ExampleComponent file="embedded_link" {...props} />
+    </div>
+  );
+});
+
 export default {
   title: 'Storybook Knobs',
   decorators: [withKnobs],

--- a/src/PlaidEmbeddedLink.tsx
+++ b/src/PlaidEmbeddedLink.tsx
@@ -1,6 +1,4 @@
-import React from 'react';
-
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import useScript from 'react-script-hook';
 
 import { PLAID_LINK_STABLE_URL } from './constants';

--- a/src/PlaidEmbeddedLink.tsx
+++ b/src/PlaidEmbeddedLink.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { useEffect, useRef } from 'react';
+import useScript from 'react-script-hook';
+
+import { PLAID_LINK_STABLE_URL } from './constants';
+import { PlaidEmbeddedLinkPropTypes } from './types';
+
+export const PlaidEmbeddedLink = (props: PlaidEmbeddedLinkPropTypes) => {
+  const { style, className, ...config } = props;
+
+  // Asynchronously load the plaid/link/stable url into the DOM
+  const [loading, error] = useScript({
+    src: PLAID_LINK_STABLE_URL,
+    checkForExisting: true,
+  });
+
+  // If the external link JS script is still loading, return prematurely
+  if (loading) {
+    return null;
+  }
+
+  if (error || !window.Plaid) {
+    // eslint-disable-next-line no-console
+    console.error('Error loading Plaid', error);
+    return null;
+  }
+
+  if (config.token == null || config.token == '') {
+    console.error('A token is required to initialize embedded Plaid Link');
+    return null;
+  }
+
+  const embeddedLinkTarget = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    // The embedded Link interface doesn't use the `usePlaidLink` hook to manage
+    // its Plaid Link instance because the embedded Link integration in link-initialize
+    // maintains its own handler internally.
+    const { destroy } = window.Plaid.createEmbedded(
+      { ...config }, embeddedLinkTarget.current as HTMLElement
+    );
+
+    // Clean up embedded Link component on unmount
+    return () => {
+      destroy();
+    }
+  }, [config, embeddedLinkTarget]);
+
+  return (
+    <div style={style} className={className} ref={embeddedLinkTarget}></div>
+  );
+};
+
+export default PlaidEmbeddedLink;

--- a/src/PlaidEmbeddedLink.tsx
+++ b/src/PlaidEmbeddedLink.tsx
@@ -15,24 +15,24 @@ export const PlaidEmbeddedLink = (props: PlaidEmbeddedLinkPropTypes) => {
     checkForExisting: true,
   });
 
-  // If the external link JS script is still loading, return prematurely
-  if (loading) {
-    return null;
-  }
-
-  if (error || !window.Plaid) {
-    // eslint-disable-next-line no-console
-    console.error('Error loading Plaid', error);
-    return null;
-  }
-
-  if (config.token == null || config.token == '') {
-    console.error('A token is required to initialize embedded Plaid Link');
-    return null;
-  }
-
   const embeddedLinkTarget = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
+    // If the external link JS script is still loading, return prematurely
+    if (loading) {
+      return;
+    }
+
+    if (error || !window.Plaid) {
+      // eslint-disable-next-line no-console
+      console.error('Error loading Plaid', error);
+      return;
+    }
+
+    if (config.token == null || config.token == '') {
+      console.error('A token is required to initialize embedded Plaid Link');
+      return;
+    }
+
     // The embedded Link interface doesn't use the `usePlaidLink` hook to manage
     // its Plaid Link instance because the embedded Link integration in link-initialize
     // maintains its own handler internally.
@@ -44,7 +44,7 @@ export const PlaidEmbeddedLink = (props: PlaidEmbeddedLinkPropTypes) => {
     return () => {
       destroy();
     }
-  }, [config, embeddedLinkTarget]);
+  }, [loading, error, config, embeddedLinkTarget]);
 
   return (
     <div style={style} className={className} ref={embeddedLinkTarget}></div>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,2 @@
+export const PLAID_LINK_STABLE_URL =
+  'https://cdn.plaid.com/link/v2/stable/link-initialize.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 export { usePlaidLink } from './usePlaidLink';
 export { PlaidLink } from './PlaidLink';
+export { PlaidEmbeddedLink } from './PlaidEmbeddedLink';
 export * from './types'

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -165,18 +165,28 @@ export type PlaidLinkPropTypes = PlaidLinkOptions & {
   style?: React.CSSProperties;
 };
 
+export type PlaidEmbeddedLinkPropTypes = PlaidLinkOptions & {
+  className?: string;
+  style?: React.CSSProperties;
+};
+
 export interface PlaidHandler {
   open: () => void;
   exit: (force?: boolean) => void;
   destroy: () => void;
-}
+};
+
+export interface PlaidEmbeddedHandler {
+  destroy: () => void;
+};
 
 export interface Plaid extends PlaidHandler {
   create: (config: PlaidLinkOptions) => PlaidHandler;
-}
+  createEmbedded: (config: PlaidLinkOptions, domTarget: HTMLElement) => PlaidEmbeddedHandler;
+};
 
 declare global {
   interface Window {
     Plaid: Plaid;
   }
-}
+};

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -174,19 +174,19 @@ export interface PlaidHandler {
   open: () => void;
   exit: (force?: boolean) => void;
   destroy: () => void;
-};
+}
 
 export interface PlaidEmbeddedHandler {
   destroy: () => void;
-};
+}
 
 export interface Plaid extends PlaidHandler {
   create: (config: PlaidLinkOptions) => PlaidHandler;
   createEmbedded: (config: PlaidLinkOptions, domTarget: HTMLElement) => PlaidEmbeddedHandler;
-};
+}
 
 declare global {
   interface Window {
     Plaid: Plaid;
   }
-};
+}

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -3,9 +3,7 @@ import useScript from 'react-script-hook';
 
 import { createPlaid, PlaidFactory } from './factory';
 import { PlaidLinkOptions, PlaidLinkOptionsWithLinkToken, PlaidLinkOptionsWithPublicKey } from './types';
-
-const PLAID_LINK_STABLE_URL =
-  'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
+import { PLAID_LINK_STABLE_URL } from './constants';
 
 const noop = () => {};
 

--- a/src/web3/useEthereumProvider.ts
+++ b/src/web3/useEthereumProvider.ts
@@ -7,9 +7,7 @@ import {
   PlaidWeb3,
   PlaidGlobalWithWeb3,
 } from '../types/web3';
-
-const PLAID_LINK_STABLE_URL =
-  'https://cdn.plaid.com/link/v2/stable/link-initialize.js';
+import { PLAID_LINK_STABLE_URL } from '../constants';
 
 const noop = () => {};
 

--- a/stories/embedded_link.tsx
+++ b/stories/embedded_link.tsx
@@ -1,0 +1,39 @@
+import React, { useCallback } from 'react';
+
+import { PlaidEmbeddedLink } from '../src';
+
+const App = props => {
+  const onSuccess = useCallback(
+    (token, metadata) => console.log('onSuccess', token, metadata),
+    []
+  );
+
+  const onEvent = useCallback(
+    (eventName, metadata) => console.log('onEvent', eventName, metadata),
+    []
+  );
+
+  const onExit = useCallback(
+    (err, metadata) => console.log('onExit', err, metadata),
+    []
+  );
+
+  const config = {
+    token: props.token,
+    onSuccess,
+    onEvent,
+    onExit,
+  };
+
+  return (
+    <PlaidEmbeddedLink
+      {...config}
+      style={{
+        height: '350px',
+        width: '350px',
+      }}
+    />
+  );
+};
+
+export default App;


### PR DESCRIPTION
- Add `<PlaidEmbeddedLink />` to support embedded Link in the React SDK
- Add embedded Link to storybook

This feature is an unreleased experimental feature that can be enabled for customers on a case-by-case basis. Contact your Account Manager to learn more.

Usage: 

```
 const config = {
    token: "link-token-123",
    onSuccess,
    onEvent,
    onExit,
  };

  return (
    <PlaidEmbeddedLink
      {...config}
      style={{
        height: '350px',
        width: '350px',
      }}
    />
  );
```

<img width="1037" alt="image" src="https://github.com/plaid/react-plaid-link/assets/129547225/1a0a53f0-feef-4d31-907c-10d34dae7986">
