### PR TITLE
Update PUBLISH.md to clarify build steps

### DIFF
--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -3,6 +3,8 @@
 **We use the `xyz` NPM package to simplify releases. This library uses a feature that is available in Bash 4 or beyond, but latest versions of macOS
 ship with an older version of Bash. If you run into issues with `xyz`, use `brew install bash` to install a newer verison of Bash.**
 
+If you run into any `npm` package versioning issues, make sure you run `make setup` rather than calling `npm install` directly.
+
 1. Create a branch to stage the release, for example `release-3.4.5` (Read [semver](https://semver.org/) to determine what type of version bump to use.)
 
 ```
@@ -25,16 +27,20 @@ make release-(patch|minor|major)
 
 5. Merge the branch
 
-#### **Manually publish to NPM**
+#### **If the `make` command errors out with an authentication issue**
 
 If `make release-*` from above errors out with an authentication issue,
 you may need to `npm login` or otherwise manually set up your `~/.npmrc` file to
 make sure you have access to publish to npm.
 
-Once you have done that, the following command will publish the latest version
-(already bumped and pushed in step 4) to the NPM registry:
+#### (dangerous) Manually publish an already-built package to npm
 
-1. Publish to npm manually
+If you've set up your npm authentication as described above, but are still seeing authentication issues when running `make release-*`, you can 
+directly publish a **built** package to the npm registry using the manual commands below. You should **only** publish the package manually using these steps
+if the build steps of the `make release-*` command were **successful**. If the build steps did not succeeed, running these commands could publish an unbuilt
+version of the package, which would lead to a broken release.
+
+1. Publish already-built package to npm manually
 
 ```bash
 npm --registry=https://registry.npmjs.com publish


### PR DESCRIPTION
- Clarifies that manual publish steps using `npm` only work if the package has already been built via `make`