### PR TITLE
fix (#327): add support for institution parameter to Plaid.open

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -55,13 +55,13 @@ const createPlaidHandler = <T extends CommonPlaidLinkOptions<{}>>(
     },
   });
 
-  const open = () => {
+  const open = (institution?: string) => {
     if (!state.plaid) {
       return;
     }
     state.open = true;
     state.onExitCallback = null;
-    state.plaid.open();
+    state.plaid.open(institution);
   };
 
   const exit = (exitOptions: any, callback: (() => void) | Function) => {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -171,7 +171,7 @@ export type PlaidEmbeddedLinkPropTypes = PlaidLinkOptions & {
 };
 
 export interface PlaidHandler {
-  open: () => void;
+  open: (institution?: string) => void;
   exit: (force?: boolean) => void;
   destroy: () => void;
 }


### PR DESCRIPTION
Fixes #327 

Fix is tested and working. Passing `ins_56` as the institution causes Plaid Link to skip the bank selection screen and go straight to bank login.