### PR TITLE
fix: recreate instance immediately

### DIFF
--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -60,6 +60,7 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
       {
         ...options,
         onLoad: () => {
+          setIframeLoaded(false);
           options.onLoad && options.onLoad();
         },
       },

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -60,7 +60,6 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
       {
         ...options,
         onLoad: () => {
-          setIframeLoaded(true);
           options.onLoad && options.onLoad();
         },
       },
@@ -85,7 +84,7 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
     }
   }, [plaid])
 
-  const ready = plaid != null && (!loading || iframeLoaded);
+  const ready = !!plaid && !loading && iframeLoaded; 
 
   const openNoOp = () => {
     if (!options.token) {

--- a/src/usePlaidLink.ts
+++ b/src/usePlaidLink.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import useScript from 'react-script-hook';
 
 import { createPlaid, PlaidFactory } from './factory';
@@ -29,14 +29,13 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
   });
 
   // internal state
-  const [plaid, setPlaid] = useState<PlaidFactory | null>(null);
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const products = ((options as PlaidLinkOptionsWithPublicKey).product || [])
     .slice()
     .sort()
     .join(',');
 
-  useEffect(() => {
+  const plaid = useMemo((): PlaidFactory | void => {
     // If the link.js script is still loading, return prematurely
     if (loading) {
       return;
@@ -57,13 +56,7 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
       return;
     }
 
-    // if an old plaid instance exists, destroy it before
-    // creating a new one
-    if (plaid != null) {
-      plaid.exit({ force: true }, () => plaid.destroy());
-    }
-
-    const next = createPlaid(
+    return createPlaid(
       {
         ...options,
         onLoad: () => {
@@ -73,11 +66,6 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
       },
       window.Plaid.create
     );
-
-    setPlaid(next);
-
-    // destroy the Plaid iframe factory
-    return () => next.exit({ force: true }, () => next.destroy());
   }, [
     loading,
     error,
@@ -85,6 +73,17 @@ export const usePlaidLink = (options: PlaidLinkOptions) => {
     options.token,
     products,
   ]);
+
+  useEffect(() => {
+    setIframeLoaded(false);
+    if (!plaid) {
+      return;
+    }
+    return () => {
+      // destroy the Plaid iframe factory when unmounting an instance
+      plaid.exit({ force: true }, () => plaid.destroy());
+    }
+  }, [plaid])
 
   const ready = plaid != null && (!loading || iframeLoaded);
 


### PR DESCRIPTION

### What
- Recreates the Plaid instance immediately in a `useMemo()` rather than a `useEffect()`
- Trashes the old Plaid instance when unmounting

### Why

I have code that takes care of invalidating expired tokens and recreates the Plaid instance when/if needed & since the Plaid token isn't resolved immediately I can't trust the `connect.open()` to be immediately pointing to the new token rather than the old one