### PR TITLE
Fix undefined exports issue

### DIFF
--- a/src/react-script-hook/index.test.tsx
+++ b/src/react-script-hook/index.test.tsx
@@ -272,4 +272,26 @@ describe('useScript', () => {
             expect(document.querySelectorAll('script').length).toBe(1);
         });
     });
+
+    it('should remove script from DOM and scripts cache when unmounted during loading', () => {
+        expect(document.querySelectorAll('script').length).toBe(0);
+        expect(Object.keys(scripts).length).toBe(0);
+        
+        const testSrc = 'http://scriptsrc/test';
+        const { unmount } = renderHook(() => useScript({ src: testSrc }));
+        
+        // Verify script was added
+        expect(document.querySelectorAll('script').length).toBe(1);
+        expect(Object.keys(scripts).length).toBe(1);
+        expect(scripts[testSrc]).toBeDefined();
+        expect(scripts[testSrc].loading).toBe(true);
+        
+        // Unmount the component while script is still loading (before load event)
+        unmount();
+        
+        // Verify script was removed from DOM and cache
+        expect(document.querySelectorAll('script').length).toBe(0);
+        expect(Object.keys(scripts).length).toBe(0);
+        expect(scripts[testSrc]).toBeUndefined();
+    });
 });

--- a/src/react-script-hook/index.tsx
+++ b/src/react-script-hook/index.tsx
@@ -131,7 +131,7 @@ export default function useScript({
             // but only applied when loading
             if (status && status.loading) {
                 scriptEl.remove();
-                delete exports.scripts[src];
+                delete scripts[src];
             }
         };
         // we need to ignore the attributes as they're a new object per call, so we'd never skip an effect call


### PR DESCRIPTION
- This closes #374 
- I added a unit test for this behavior (now that this logic is no longer done via patch-package), but the unit test would _also_ not have caught this behavior because `exports` / `exports.scripts` is actually defined in the NodeJS runtime (which is also why this didn't get caught by TypeScript)
- ~I am looking into why the Storybooks didn't catch this / surface this~
  - Ah right, the storybooks aren't setup to hit this exact case (unmounting while the script is still loading)
- Will release this as 4.0.1