### PR TITLE
Update link_token docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ return (
 Please refer to the [official Plaid Link
 docs](https://plaid.com/docs/link/web/) for a more holistic understanding of
 the various Link options and the
-[`link_token`](https://plaid.com/docs/api/tokens/#linktokencreate).
+[`link_token`](https://plaid.com/docs/api/link/#linktokencreate).
 
 #### `usePlaidLink` arguments
 


### PR DESCRIPTION
The README's \`link_token\` reference pointed at \`https://plaid.com/docs/api/tokens/#linktokencreate\`, which 404s now that Plaid migrated the Link Token reference under \`https://plaid.com/docs/api/link/\`. The \`#linktokencreate\` anchor still resolves on the new page.

## Test plan
- [ ] Click the \`link_token\` link in the rendered README and confirm it scrolls to the \`/link/token/create\` section of the Link API reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: 80ee54fa-3880-4c3c-b81d-9bf74c3adb2c