### PR TITLE
docs: correct onSuccess JSDoc + receivedRedirectUri type docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ the various Link options and the
 | `onExit`              | `(error: null \| PlaidLinkError, metadata: PlaidLinkOnExitMetadata) => void`              |
 | `onEvent`             | `(eventName: PlaidLinkStableEvent \| string, metadata: PlaidLinkOnEventMetadata) => void` |
 | `onLoad`              | `() => void`                                                                              |
-| `receivedRedirectUri` | `string \| null \| undefined`                                                             |
+| `receivedRedirectUri` | `string \| undefined`                                                                     |
 | `cspNonce`            | `string \| undefined`                                                                     |
 
 #### Content Security Policy nonce

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -89,8 +89,8 @@ export type PlaidLinkOnEvent = (
 export type PlaidLinkOnLoad = () => void;
 
 export interface CommonPlaidLinkOptions<T> {
-  // A function that is called when a user has successfully connecter an Item.
-  // The function should expect two arguments, the public_key and a metadata object
+  // A function that is called when a user has successfully connected an Item.
+  // The function should expect two arguments, the public_token and a metadata object
   onSuccess: T;
   // A callback that is called when a user has specifically exited Link flow
   onExit?: PlaidLinkOnExit;


### PR DESCRIPTION
## Summary

Two small documentation fixes filed as separate issues but touching adjacent surfaces — combined into a single PR.

### 1. `CommonPlaidLinkOptions.onSuccess` JSDoc (closes #397)

`src/types/index.ts:92-93` referenced `public_key` and had a `connecter`/`connected` typo. The first callback argument is `public_token` since the Link Token migration; `public_key` is the deprecated public-key auth flow and is no longer what consumers receive here. The matching `PlaidLinkOnSuccess` type already uses `public_token`.

```diff
-  // A function that is called when a user has successfully connecter an Item.
-  // The function should expect two arguments, the public_key and a metadata object
+  // A function that is called when a user has successfully connected an Item.
+  // The function should expect two arguments, the public_token and a metadata object
   onSuccess: T;
```

The other surviving `public_key` references in this file are inside the `PlaidLinkOptionsWithPublicKey` interface, which is the deprecated public-key flow — those are intentional and left untouched.

### 2. `receivedRedirectUri` README/type mismatch (closes #398)

`README.md:87` documented `receivedRedirectUri` as `string | null | undefined`, but the type at `src/types/index.ts:156` only permits `string | undefined`. Updated the README to match the type — that's the minimal, lower-risk path; widening the type would change the runtime contract.

```diff
-| `receivedRedirectUri` | `string \| null \| undefined`                                                             |
+| `receivedRedirectUri` | `string \| undefined`                                                                     |
```

## Test plan

- [x] Comment-only / docs-only change — no runtime behavior change
- [x] `PlaidLinkOnSuccess` type already uses `public_token`, so JSDoc now matches the type
- [x] `receivedRedirectUri` type unchanged; README now matches it