### PR TITLE
fix: correct PlaidAccount type (mask/verification_status nullable, add class_type)

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,10 +3,11 @@ import React from 'react';
 export interface PlaidAccount {
   id: string;
   name: string;
-  mask: string;
+  mask: string | null;
   type: string;
   subtype: string;
-  verification_status: string;
+  verification_status: string | null;
+  class_type: string | null;
 }
 
 export interface PlaidInstitution {


### PR DESCRIPTION
## Summary
- `mask` and `verification_status` widened to `string | null` per Plaid docs
- Added missing `class_type: string | null` field

Fixes #377

## Test plan
- [x] `make lint`
- [x] `make test` (28/28 passed)
- [x] `make clean build`