### PR TITLE
Fix iframe cleanup after successful Link completion

### DIFF
--- a/src/factory.ts
+++ b/src/factory.ts
@@ -48,6 +48,10 @@ const createPlaidHandler = <T extends CommonPlaidLinkOptions<{}>>(
 
   state.plaid = creator({
     ...config,
+    onSuccess: (publicToken, metadata) => {
+      state.open = false;
+      config.onSuccess(publicToken, metadata);
+    },
     onExit: (error, metadata) => {
       state.open = false;
       config.onExit && config.onExit(error, metadata);

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -2,6 +2,8 @@ import {
   PlaidLinkOptions,
   PlaidHandler,
   PlaidHandlerSubmissionData,
+  PlaidLinkOnSuccess,
+  PlaidLinkOnSuccessMetadata,
   CommonPlaidLinkOptions,
 } from './types';
 
@@ -31,7 +33,9 @@ const renameKeyInObject = (
 /**
  * Wrap link handler creation and instance to clean up iframe via destroy() method
  */
-const createPlaidHandler = <T extends CommonPlaidLinkOptions<{}>>(
+const createPlaidHandler = <
+  T extends CommonPlaidLinkOptions<PlaidLinkOnSuccess>
+>(
   config: T,
   creator: (config: T) => PlaidHandler
 ) => {
@@ -48,7 +52,7 @@ const createPlaidHandler = <T extends CommonPlaidLinkOptions<{}>>(
 
   state.plaid = creator({
     ...config,
-    onSuccess: (publicToken, metadata) => {
+    onSuccess: (publicToken: string, metadata: PlaidLinkOnSuccessMetadata) => {
       state.open = false;
       config.onSuccess(publicToken, metadata);
     },

--- a/src/usePlaidLink.test.tsx
+++ b/src/usePlaidLink.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { usePlaidLink, PlaidLinkOptions, PlaidLinkOptionsWithLinkToken } from './';
 
 import useScript from './react-script-hook';
@@ -168,5 +168,19 @@ describe('usePlaidLink', () => {
     rerender(<HookComponent config={config} />);
     expect(screen.getByText(ReadyState.READY));
     expect(screen.getByText(ReadyState.NO_ERROR));
+  });
+
+  it('should destroy the Plaid instance on unmount after success', () => {
+    const { unmount } = render(<HookComponent config={config} />);
+    const plaidHandler = (window.Plaid.create as jest.Mock).mock.results[0]
+      .value;
+    const plaidConfig = (window.Plaid.create as jest.Mock).mock.calls[0][0];
+
+    fireEvent.click(screen.getByRole('button'));
+    plaidConfig.onSuccess('public-token', {});
+    unmount();
+
+    expect(plaidHandler.exit).not.toHaveBeenCalled();
+    expect(plaidHandler.destroy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Successful Link completion left the wrapper marked open, so unmount cleanup waited for an exit callback that would never arrive. Marking the instance closed in the success callback lets cleanup destroy the iframe immediately and includes regression coverage.

Closes #325.