### PR TITLE
Release 4.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## Unreleased
 
-- Add `cspNonce` to support nonce-based Content Security Policies on `usePlaidLink` and `PlaidEmbeddedLink`.
+## 4.2.0
+
+- Add `cspNonce` to support nonce-based Content Security Policies on `usePlaidLink` and `PlaidEmbeddedLink` (partially fixes [#118](https://github.com/plaid/react-plaid-link/issues/118)).
+- Fix iframe cleanup after successful Link completion (fixes [#325](https://github.com/plaid/react-plaid-link/issues/325)).
+- Preserve the shared Link script while another hook is still loading (fixes [#268](https://github.com/plaid/react-plaid-link/issues/268)).
+- Correct nullable `PlaidAccount` fields and add `class_type` (fixes [#377](https://github.com/plaid/react-plaid-link/issues/377)).
+- Correct the `onSuccess` callback documentation (fixes [#397](https://github.com/plaid/react-plaid-link/issues/397)).
+- Correct the documented `receivedRedirectUri` type (fixes [#398](https://github.com/plaid/react-plaid-link/issues/398)).
+- Document invalid Link token recovery and refresh README examples and links (fixes [#258](https://github.com/plaid/react-plaid-link/issues/258)).
 
 ## 4.1.1 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-plaid-link",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "A React component for Plaid Link",
   "registry": "https://registry.npmjs.org",
   "files": [


### PR DESCRIPTION
Updates the changelog and package version for 4.2.0, covering CSP nonce support, lifecycle fixes, type corrections, and documentation updates.

`react-plaid-link@4.2.0` and `v4.2.0` are published.