### PR TITLE
Test React 16 through 19 compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        react: [18, 19]
+        include:
+          - react: 16.8.6
+            react-types: 16
+            testing-library: 12.1.5
+          - react: 17.0.2
+            react-types: 17
+            testing-library: 12.1.5
+          - react: 18.3.1
+            react-types: 18
+            testing-library: 16.3.2
+          - react: 19.2.8
+            react-types: 19
+            testing-library: 16.3.2
 
     steps:
       - uses: actions/checkout@v7
@@ -37,6 +49,7 @@ jobs:
           yarn add --dev --ignore-scripts --no-lockfile
           react@${{ matrix.react }}
           react-dom@${{ matrix.react }}
-          @types/react@${{ matrix.react }}
-          @types/react-dom@${{ matrix.react }}
+          @types/react@${{ matrix.react-types }}
+          @types/react-dom@${{ matrix.react-types }}
+          @testing-library/react@${{ matrix.testing-library }}
       - run: make typecheck test

--- a/src/react-script-hook/index.test.tsx
+++ b/src/react-script-hook/index.test.tsx
@@ -1,6 +1,35 @@
-import { act, renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { act, render } from '@testing-library/react';
 
 import useScript, { scripts } from './';
+
+const renderHook = <Result, Props = undefined>(
+    callback: (props: Props) => Result,
+    options?: { initialProps: Props },
+) => {
+    let current!: Result;
+
+    const Hook: React.FC<{ hookProps: Props }> = ({ hookProps }) => {
+        current = callback(hookProps);
+        return null;
+    };
+
+    const initialProps = options
+        ? options.initialProps
+        : (undefined as unknown as Props);
+    const handle = render(<Hook hookProps={initialProps} />);
+
+    return {
+        result: {
+            get current() {
+                return current;
+            },
+        },
+        rerender: (props: Props) =>
+            handle.rerender(<Hook hookProps={props} />),
+        unmount: handle.unmount,
+    };
+};
 
 describe('useScript', () => {
     beforeEach(() => {
@@ -283,7 +312,7 @@ describe('useScript', () => {
         expect(document.querySelectorAll('script').length).toBe(0);
     });
 
-    it('should append script after src change from null', async () => {
+    it('should append script after src change from null', () => {
         expect(document.querySelectorAll('script').length).toBe(0);
 
         const props = { src: null };
@@ -300,9 +329,7 @@ describe('useScript', () => {
 
         props.src = 'http://scriptsrc/' as any;
         rerender(props);
-        await waitFor(() => {
-            expect(document.querySelectorAll('script').length).toBe(1);
-        });
+        expect(document.querySelectorAll('script').length).toBe(1);
     });
 
     it('should remove script from DOM and scripts cache when unmounted during loading', () => {


### PR DESCRIPTION
React 16 and 17 remain supported but are not covered by the compatibility workflow.

This adds pinned React 16.8–19 lanes with matching Testing Library versions and makes the hook tests work across both test stacks.