### PR TITLE
Release 5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ See the [5.0.0 migration guide](MIGRATION.md) for required TypeScript updates.
   that do not create an Item.
 - Replace the `exit(force)` signature with `exit({ force })` to match the Link
   Web SDK.
-- Correct Layer submission types so phone number and date of birth can be
+- Correct Layer submission types so phone number and date of birth must be
   submitted separately.
 - Add stable Layer and Identity Match events.
 - Add a complete Layer React example and integration guidance.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 5.0.0
+
+See the [5.0.0 migration guide](MIGRATION.md) for required TypeScript updates.
+
+- Allow `public_token` to be `null` in `onSuccess` callbacks for Link flows
+  that do not create an Item.
+- Replace the `exit(force)` signature with `exit({ force })` to match the Link
+  Web SDK.
 - Correct Layer submission types so phone number and date of birth can be
   submitted separately.
 - Add stable Layer and Identity Match events.

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,69 @@
+# Migrating to 5.0.0
+
+Version 5.0.0 corrects public TypeScript definitions to match the Link Web SDK.
+Runtime behavior is unchanged.
+
+## Handle nullable public tokens
+
+The `public_token` passed to `onSuccess` is now typed as `string | null`. Check
+for `null` before using it in flows that do not create an Item:
+
+```tsx
+const onSuccess: PlaidLinkOnSuccess = (publicToken, metadata) => {
+  if (publicToken) {
+    exchangePublicToken(publicToken);
+  }
+};
+```
+
+Item-based flows continue to return a public token.
+
+## Pass exit options as an object
+
+Replace the legacy boolean argument:
+
+```tsx
+exit(true);
+```
+
+with the Link Web SDK options object:
+
+```tsx
+exit({ force: true });
+```
+
+Call `exit()` without arguments for a graceful exit.
+
+## Submit Layer phone number and date of birth separately
+
+Submit a phone number first:
+
+```tsx
+submit({ phone_number: '+14155550123' });
+```
+
+After receiving `LAYER_NOT_AVAILABLE`, submit date of birth separately:
+
+```tsx
+submit({ date_of_birth: '1975-01-18' });
+```
+
+Do not include both fields or use `null` placeholders in the same submission.
+
+## Create handlers before calling handler methods
+
+The global `window.Plaid` type no longer includes handler methods. Create a
+handler before calling `open`, `submit`, `exit`, or `destroy`:
+
+```tsx
+const handler = window.Plaid.create(config);
+handler.open();
+```
+
+Applications using `usePlaidLink` do not need to create a handler directly.
+
+## Update strict metadata handling
+
+The corrected callback types include additional event metadata fields and
+nullable `display_message` and `transfer_status` values. Add null checks where
+needed and update any manually constructed callback metadata used in tests.

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
   "name": "react-plaid-link",
-  "version": "4.2.0",
+  "version": "5.0.0",
   "description": "A React component for Plaid Link",
   "registry": "https://registry.npmjs.org",
   "files": [
     "dist",
     "src",
-    "LICENSE"
+    "LICENSE",
+    "MIGRATION.md"
   ],
   "main": "dist/index.js",
   "module": "dist/index.esm.js",


### PR DESCRIPTION
The corrected Link callback, exit, and Layer submission types require explicit TypeScript migrations.

This bumps the package to 5.0.0, moves the unreleased changes into release notes, and ships a concise migration guide.